### PR TITLE
Hotfix: Progressbar/Time Remaining More Accurate During Import

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ phases:
     inputs:
       versionSpec: 3.5
   - script: |
-       pip3 install -r src/requirements.txt
+       pip3 install --no-use-pep517 -r src/requirements.txt
     displayName: install requirements
   - script: |
        python3 -m pylint src
@@ -86,7 +86,7 @@ phases:
     name: Hosted macOS
   steps:
   - script: |
-       pip3 install -r src/requirements.txt
+       pip3 install --no-use-pep517 -r src/requirements.txt
     displayName: install requirements
   - script: |
        python3 -m pylint src

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ phases:
     name: Hosted macOS
   steps:
   - script: |
-       pip3 install --no-use-pep517 -r src/requirements.txt
+       pip3 install -r src/requirements.txt
     displayName: install requirements
   - script: |
        python3 -m pylint src

--- a/src/cadet.py
+++ b/src/cadet.py
@@ -3,7 +3,6 @@
 This CLI tool allows a user to upload CSV and TSV files to an Azure CosmosDB instance configured
 to use DocumentDB.
 """
-
 import csv
 import os
 import sys
@@ -14,6 +13,8 @@ DELIMITERS = {
     'CSV': ',',
     'TSV': '\t'
 }
+
+FILE_ENDINGS = ('.CSV', '.TSV')
 
 
 @click.version_option('1.0.0')
@@ -68,7 +69,7 @@ def upload(source, type_, collection_name, database_name, primary_key, uri, conn
     """
     # Make sure it's a CSV or TSV
     type_ = type_.upper()
-    if type_ not in ['CSV', 'TSV'] or not source.upper().endswith(('.CSV', '.TSV')):
+    if type_ not in DELIMITERS or not source.upper().endswith(FILE_ENDINGS):
         raise click.BadParameter('We currently only support CSV and TSV uploads from Cadet')
 
     # You must have either the connection string OR (endpoint and key) to connect
@@ -147,10 +148,10 @@ def read_and_upload(source_path, file_type, client, collection_link):
                         document[col] = row[ind]
                     try:
                         client.UpsertItem(collection_link, document)
-                        status_bar.update(sys.getsizeof(document))
+                        status_bar.update(sys.getsizeof(row))
                     except:
                         raise click.ClickException('Upload failed')
-    click.echo('Upload complete!')
+        click.echo('Upload complete!')
 
 
 if __name__ == '__main__':

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -17,7 +17,7 @@ more-itertools==5.0.0
 pefile==2018.8.8
 pluggy==0.8.0
 py==1.7.0
-PyInstaller==3.4
+pyinstaller==3.4
 pylint==2.2.2
 pytest==4.0.2
 pywin32-ctypes==0.2.0


### PR DESCRIPTION
Fixes #9.
Swaps in the progress bar update unit to the row and not the document size. Also adds in more references to the delimiter and file endings variables for easier future updating,

Now the progress bar more accurately reflects the time left on the job uploading.